### PR TITLE
Added Node.js HTTP/2 series with examples

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -36,7 +36,14 @@ Welcome to the comprehensive series on Node.js with TypeScript! This collection 
 
 11. [**Series #11: Node.js Cluster: sharing the workload between multiple processes**](https://github.com/muneer-ahmed-khan/typescript-node-series/tree/master/series-11)
     - Improve application performance by parallelizing the execution of Node.js processes across multiple cores.
+
+
+12. [**Series #12: Node.js HTTP/2 Protocol: use of http2 protocol with Node js**](https://github.com/muneer-ahmed-khan/typescript-node-series/tree/master/series-12)
+    - usage of http/2 protocol
+   
     
+
+
 
 
 

--- a/series-12/.gitignore
+++ b/series-12/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.DS_Store
+certificate.pem
+key.pem

--- a/series-12/ReadMe.md
+++ b/series-12/ReadMe.md
@@ -1,0 +1,42 @@
+### Usage
+- The ```examples``` folder contain multiple example of http/2 protocol.
+
+- Uncomment the import statement of any imported examples file in ```main.js``` to see the result.
+
+- run the program with command
+``` npm start ```
+
+
+- # Evolution of HTTP
+
+## HTTP/0.9 (1991)
+- Initial version for basic HTML transfer.
+- Limited to GET method, lacked headers, and had no status codes.
+- Server responses included HTML error descriptions.
+
+## HTTP/1.0 (1996)
+- Significant enhancements.
+- Introduced status codes, additional methods (e.g., POST), and headers.
+- Enabled transmission of various file types using Content-Type header.
+
+## HTTP/1.1 (1997)
+- Introduced further improvements.
+- Added methods like OPTIONS and Keep-Alive header.
+
+## HTTP/2 (2015)
+- Introduced multiplexing, allowing concurrent requests and responses over a single connection, aiming to reduce latency.
+
+## HTTP/3 (2020)
+- Latest version based on QUIC, focusing on performance and security with default multiplexing and encryption.
+
+### Main Points
+- ``````HTTP/1.1`````` Allowed a single connection for multiple requests, addressing **head-of-line blocking**.
+- **Head-of-line blocking** is a phenomenon that occurs in network communication, particularly in the context of ```HTTP/1.1```.
+- It refers to the situation where requests made over a single connection are processed sequentially, and if one request is delayed or blocked, it holds up the processing of subsequent requests.
+- In ```HTTP/1.1```, multiple requests can be sent over a single connection.
+- However, if one of these requests encounters a delay, for example, due to a complex server-side operation or a slow response, the subsequent requests must wait in line behind the delayed request.
+- This waiting creates a **"head-of-line"** effect, where the first request in line becomes a bottleneck, blocking the progress of others.
+- HTTP/2 solves **head-of-line-blocking** this issue by allowing one connection to handle multiple requests at once.
+- HTTP/2 uses a new header compression algorithm that we call HPACK. HTTP/2 more secure, but it is also faster in some cases.
+- With the Server Push, we can now populate data in a client cache.
+- HTTP/2 aims to improve performance by meeting the needs of web pages that get more complex

--- a/series-12/certificate-example.pem
+++ b/series-12/certificate-example.pem
@@ -1,0 +1,3 @@
+-----BEGIN CERTIFICATE-----
+your CERTIFICATE details here
+-----END CERTIFICATE-----

--- a/series-12/examples/http-2-server-cache.ts
+++ b/series-12/examples/http-2-server-cache.ts
@@ -1,0 +1,59 @@
+import * as http2 from "http2";
+import * as fs from "fs";
+import * as util from "util";
+
+const readFile = util.promisify(fs.readFile);
+
+async function startServer() {
+  const [key, cert] = await Promise.all([
+    readFile("key.pem"),
+    readFile("certificate.pem"),
+  ]);
+
+  const server = http2.createSecureServer({ key, cert }).listen(8080, () => {
+    console.log("Server started");
+  });
+
+  server.on("stream", (stream, headers) => {
+    const path = headers[":path"];
+    switch (path) {
+      case "/": {
+        stream.respond({
+          "content-type": "text/html",
+          ":status": 200,
+        });
+        stream.end(` 
+            <head>
+              <link rel="stylesheet" type="text/css" href="style.css">
+            </head>
+            <body>
+              <h1>Hello World</h1>
+            </body>
+          `);
+        break;
+      }
+      case "/style.css": {
+        stream.respond({
+          "content-type": "text/css",
+          ":status": 200,
+        });
+        stream.end(`
+            body {
+              color: red;
+            }
+          `);
+        break;
+      }
+      default: {
+        stream.respond({
+          ":status": 404,
+        });
+        stream.end();
+      }
+    }
+  });
+
+  server.on("error", (err) => console.error(err));
+}
+
+startServer();

--- a/series-12/examples/http-2-server-push.ts
+++ b/series-12/examples/http-2-server-push.ts
@@ -1,0 +1,74 @@
+import * as http2 from "http2";
+import * as fs from "fs";
+import * as util from "util";
+
+const readFile = util.promisify(fs.readFile);
+
+async function startServer() {
+  const [key, cert] = await Promise.all([
+    readFile("key.pem"),
+    readFile("certificate.pem"),
+  ]);
+
+  const server = http2
+    .createSecureServer({ allowHTTP1: false, key, cert })
+    .listen(8080, () => {
+      console.log("Server started");
+    });
+
+  server.on("stream", (stream, headers) => {
+    if (!stream.pushAllowed) return;
+    const path = headers[":path"];
+    switch (path) {
+      case "/": {
+        stream.pushStream({ ":path": "/style.css" }, (err, pushStream) => {
+          if (err) throw err;
+          pushStream.respond({
+            "content-type": "text/css",
+            ":status": 200,
+          });
+          pushStream.end(`
+          body {
+            color: red;
+          }
+        `);
+        });
+        stream.respond({
+          "content-type": "text/html",
+          ":status": 200,
+        });
+        stream.end(` 
+        <head>
+          <link rel="stylesheet" type="text/css" href="style.css">
+        </head>
+        <body>
+          <h1>Hello World</h1>
+        </body>
+      `);
+        break;
+      }
+      case "/style.css": {
+        stream.respond({
+          "content-type": "text/css",
+          ":status": 200,
+        });
+        stream.end(`
+        body {
+          color: red;
+        }
+      `);
+        break;
+      }
+      default: {
+        stream.respond({
+          ":status": 404,
+        });
+        stream.end();
+      }
+    }
+  });
+
+  server.on("error", (err) => console.error(err));
+}
+
+startServer();

--- a/series-12/examples/http-2.ts
+++ b/series-12/examples/http-2.ts
@@ -1,0 +1,28 @@
+import * as http2 from "http2";
+import * as fs from "fs";
+import * as util from "util";
+
+const readFile = util.promisify(fs.readFile);
+
+async function startServer() {
+  const [key, cert] = await Promise.all([
+    readFile("key.pem"),
+    readFile("certificate.pem"),
+  ]);
+
+  const server = http2.createSecureServer({ key, cert }).listen(8080, () => {
+    console.log("Server started");
+  });
+
+  server.on("stream", (stream, headers) => {
+    stream.respond({
+      "content-type": "text/html",
+      ":status": 200,
+    });
+    stream.end("<h1>Hello World</h1>");
+  });
+
+  server.on("error", (err) => console.error(err));
+}
+
+startServer();

--- a/series-12/key-example.pem
+++ b/series-12/key-example.pem
@@ -1,0 +1,3 @@
+-----BEGIN PRIVATE KEY-----
+your PRIVATE key details
+-----END PRIVATE KEY-----

--- a/series-12/main.ts
+++ b/series-12/main.ts
@@ -1,0 +1,3 @@
+// import "./examples/http-2";
+// import "./examples/http-2-server-cache";
+import "./examples/http-2-server-push";

--- a/series-12/package-lock.json
+++ b/series-12/package-lock.json
@@ -1,0 +1,213 @@
+{
+  "name": "typescript-node-series-1",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "typescript-node-series-1",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@types/node": "^20.11.5",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.3.3"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.11.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.6.tgz",
+      "integrity": "sha512-+EOokTnksGVgip2PbYbr3xnR7kZigh4LbybAfBAw5BpnQ+FqBYUsvCEjYd70IXKlbohQ64mzEYmMtlWUY8q//Q==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/series-12/package.json
+++ b/series-12/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "typescript-node-series-1",
+  "version": "1.0.0",
+  "description": "#1",
+  "main": "index.js",
+  "scripts": {
+    "start": "ts-node ./main.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@types/node": "^20.11.5",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.3.3"
+  }
+}

--- a/series-12/reqeust.http
+++ b/series-12/reqeust.http
@@ -1,0 +1,2 @@
+GET https://localhost:8080/ HTTP/2.0
+ 

--- a/series-12/tsconfig.json
+++ b/series-12/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "sourceMap": true,
+    "target": "es2017",
+    "alwaysStrict": false,
+    "noImplicitAny": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
+  },
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Expanded the educational content to include a new HTTP/2 section in the Node.js with TypeScript series, providing examples and detailed historical context of HTTP evolution. Additionally, a `.gitignore` was created to prevent certificate files from being tracked, and necessary configuration files for the series' code were added to ensure that learners can seamlessly run the examples and understand the use of HTTP/2 in Node.js applications.