### PR TITLE
added series 13

### DIFF
--- a/series-01/package.json
+++ b/series-01/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "typescript-node-series-1",
+  "name": "typescript-node-series-01",
   "version": "1.0.0",
   "description": "#1",
   "main": "index.js",

--- a/series-02/package.json
+++ b/series-02/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "typescript-node-series-1",
+  "name": "typescript-node-series-02",
   "version": "1.0.0",
-  "description": "#1",
+  "description": "#2",
   "main": "index.js",
   "scripts": {
     "start": "ts-node ./main.ts"

--- a/series-03/package.json
+++ b/series-03/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "typescript-node-series-1",
+  "name": "typescript-node-series-03",
   "version": "1.0.0",
-  "description": "#1",
+  "description": "#3",
   "main": "index.js",
   "scripts": {
     "start": "ts-node ./main.ts"

--- a/series-05/package.json
+++ b/series-05/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "typescript-node-series-1",
+  "name": "typescript-node-series-05",
   "version": "1.0.0",
-  "description": "#1",
+  "description": "#5",
   "main": "index.js",
   "scripts": {
     "start": "ts-node ./main.ts"

--- a/series-06/package.json
+++ b/series-06/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "typescript-node-series-1",
+  "name": "typescript-node-series-06",
   "version": "1.0.0",
-  "description": "#1",
+  "description": "#6",
   "main": "index.js",
   "scripts": {
     "start": "ts-node ./main.ts"

--- a/series-07/package.json
+++ b/series-07/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "typescript-node-series-1",
+  "name": "typescript-node-series-07",
   "version": "1.0.0",
-  "description": "#1",
+  "description": "#7",
   "main": "index.js",
   "scripts": {
     "start": "ts-node ./main.ts"

--- a/series-08/package.json
+++ b/series-08/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "typescript-node-series-1",
+  "name": "typescript-node-series-08",
   "version": "1.0.0",
-  "description": "#1",
+  "description": "#8",
   "main": "index.js",
   "scripts": {
     "start": "ts-node ./main.ts"

--- a/series-09/package.json
+++ b/series-09/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "typescript-node-series-1",
+  "name": "typescript-node-series-09",
   "version": "1.0.0",
-  "description": "#1",
+  "description": "#9",
   "main": "index.js",
   "scripts": {
     "start": "ts-node ./main.ts"

--- a/series-10/package.json
+++ b/series-10/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "typescript-node-series-1",
+  "name": "typescript-node-series-10",
   "version": "1.0.0",
-  "description": "#1",
+  "description": "#10",
   "main": "index.js",
   "scripts": {
     "start": "ts-node ./main.ts"

--- a/series-11/package.json
+++ b/series-11/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "typescript-node-series-1",
+  "name": "typescript-node-series-11",
   "version": "1.0.0",
-  "description": "#1",
+  "description": "#11",
   "main": "index.js",
   "scripts": {
     "start": "ts-node ./main.ts"

--- a/series-12/package.json
+++ b/series-12/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "typescript-node-series-1",
+  "name": "typescript-node-series-12",
   "version": "1.0.0",
-  "description": "#1",
+  "description": "#12",
   "main": "index.js",
   "scripts": {
     "start": "ts-node ./main.ts"

--- a/series-13/.gitignore
+++ b/series-13/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.DS_Store

--- a/series-13/ReadMe.md
+++ b/series-13/ReadMe.md
@@ -1,0 +1,30 @@
+### Usage
+- The ```examples``` folder contain multiple example of worker threads.
+
+- Uncomment the import statement of any imported examples file in ```main.js``` to see the result.
+
+- run the program with command
+``` npm start ```
+
+### Main Points
+- The ```child process``` module enables the creation of additional Node.js processes, each with its own memory space.
+- Child processes operate independently, managing their own environment for running Node.js code.
+- Child processes takes a bit memory and takes some time to run.
+- Threads, compared to multiple processes, are lighter when it comes to resources.
+- With the  new Worker, we create a Worker in a similar way that we create a child process.
+- For ```.ts files``` When using the child process module, the new process inherits the  ```process.execArgv``` property and therefore it runs with TypeScript but it doesn't happen with worker thread.
+- We can use the  ```workerData``` parameter to send data to the newly created worker.
+- When you are inside of a worker, you can read the ```workerData``` by importing it from the **Worker Threads** module.
+- The easiest way to communicate the worker thread with the main thread is to use  ```parentPort``` that can be imported inside of a worker.
+- We can use the  ```postMessage``` function to send data back to the main thread.
+- We can pass data through Threads with ```parentPort```, ```workerData``` and ```MessageChannel```.
+- ```MessageChannel``` does not have any methods on its own. The only two properties it has are  ```port1``` and  ```port2```, both instances of ```MessagePort```.
+- The ```MessageChannel``` is capable of working without involving any Worker Threads.
+- The  ```transferList``` that the error mentions is an additional argument of the  ```postMessage``` function.
+- The  ```transferList``` doesn't clone the the port but return the original object .
+- ```postMessage``` By default, creates a clone of the data that we send, but we can change that behavior with the  ```transferList```.
+-  Array is cloned in the ```transferList``` list. The more complex the data structure, the more computing power it takes to clone it.
+- ```ArrayBuffer``` distinct from the Buffer is an easy method is to use representing an array of 8-bit unsigned integers without cloning.
+- ```ArrayBuffer``` data is not available in main thread while used again.
+- ```SharedArrayBufferTo```  create Uint8Array using a special type of a buffer.
+- This way the array is neither cloned, nor it is unavailable to the sender.

--- a/series-13/examples/main-thread-message-channel-array-buffer.ts
+++ b/series-13/examples/main-thread-message-channel-array-buffer.ts
@@ -1,0 +1,24 @@
+import { Worker, MessageChannel } from "worker_threads";
+const { port1, port2 } = new MessageChannel();
+
+const worker = new Worker("./worker.js", {
+  workerData: {
+    path: "./examples/worker-thread-message-channel-array-buffer.ts",
+  },
+});
+
+port1.on("message", async (result) => {
+  console.log("Message received on Main thread with factorial result", result);
+  await worker.terminate();
+});
+
+// array is cloned hence more computational power
+// const numbers: number[] = [11, 12, 13, 14, 15];
+// worker.postMessage({ port: port2, value: numbers }, [port2]);
+
+// not clone and work fine but after byte 256 it start from 0 again
+const array = new Uint8Array([11, 12, 13, 14, 15]);
+worker.postMessage({ port: port2, value: array }, [port2, array.buffer]);
+
+// it is detected from here
+// console.log(array.buffer);

--- a/series-13/examples/main-thread-message-channel-shared-array-buffer.ts
+++ b/series-13/examples/main-thread-message-channel-shared-array-buffer.ts
@@ -1,0 +1,24 @@
+import { Worker, MessageChannel } from "worker_threads";
+const { port1, port2 } = new MessageChannel();
+
+const worker = new Worker("./worker.js", {
+  workerData: {
+    path: "./examples/worker-thread-message-channel-shared-array-buffer.ts",
+  },
+});
+
+port1.on("message", async (result) => {
+  console.log("Message received on Main thread with factorial result", result);
+  await worker.terminate();
+});
+
+const sharedArrayBuffer = new SharedArrayBuffer(2);
+const array = new Uint8Array(sharedArrayBuffer);
+
+array[0] = 11;
+array[1] = 12;
+
+worker.postMessage({ port: port2, value: array }, [port2]);
+
+// it is detected from here
+console.log(array.buffer);

--- a/series-13/examples/main-thread-message-channel.ts
+++ b/series-13/examples/main-thread-message-channel.ts
@@ -1,0 +1,15 @@
+import { Worker, MessageChannel } from "worker_threads";
+const { port1, port2 } = new MessageChannel();
+
+const worker = new Worker("./worker.js", {
+  workerData: {
+    path: "./examples/worker-thread-message-channel.ts",
+  },
+});
+
+port1.on("message", async (result) => {
+  console.log("Message received on Main thread with factorial result", result);
+  await worker.terminate();
+});
+
+worker.postMessage({ port: port2, value: 15 }, [port2]);

--- a/series-13/examples/main-thread.ts
+++ b/series-13/examples/main-thread.ts
@@ -1,0 +1,12 @@
+import { Worker } from "worker_threads";
+
+const worker = new Worker("./worker.js", {
+  workerData: {
+    value: 15,
+    path: "./examples/worker-thread.ts",
+  },
+});
+
+worker.on("message", (result) => {
+  console.log(result);
+});

--- a/series-13/examples/worker-thread-message-channel-array-buffer.ts
+++ b/series-13/examples/worker-thread-message-channel-array-buffer.ts
@@ -1,0 +1,23 @@
+import { parentPort, MessagePort } from "worker_threads";
+
+interface Data {
+  port: MessagePort;
+  value: number[];
+}
+
+function factorial(n: number): number {
+  if (n === 1 || n === 0) {
+    return 1;
+  }
+  return factorial(n - 1) * n;
+}
+
+parentPort.on("message", (data: Data) => {
+  const { port, value } = data;
+
+  console.log("Message received on worker thread with factorial value", value);
+
+  value.forEach((number: number) => {
+    port.postMessage(factorial(number));
+  });
+});

--- a/series-13/examples/worker-thread-message-channel-shared-array-buffer.ts
+++ b/series-13/examples/worker-thread-message-channel-shared-array-buffer.ts
@@ -1,0 +1,23 @@
+import { parentPort, MessagePort } from "worker_threads";
+
+interface Data {
+  port: MessagePort;
+  value: number[];
+}
+
+function factorial(n: number): number {
+  if (n === 1 || n === 0) {
+    return 1;
+  }
+  return factorial(n - 1) * n;
+}
+
+parentPort.on("message", (data: Data) => {
+  const { port, value } = data;
+
+  console.log("Message received on worker thread with factorial value", value);
+
+  value.forEach((number: number) => {
+    port.postMessage(factorial(number));
+  });
+});

--- a/series-13/examples/worker-thread-message-channel.ts
+++ b/series-13/examples/worker-thread-message-channel.ts
@@ -1,0 +1,21 @@
+import { parentPort, MessagePort } from "worker_threads";
+
+interface Data {
+  port: MessagePort;
+  value: number;
+}
+
+function factorial(n: number): number {
+  if (n === 1 || n === 0) {
+    return 1;
+  }
+  return factorial(n - 1) * n;
+}
+
+parentPort.on("message", (data: Data) => {
+  const { port, value } = data;
+
+  console.log("Message received on worker thread with factorial value", value);
+
+  port.postMessage(factorial(value));
+});

--- a/series-13/examples/worker-thread.ts
+++ b/series-13/examples/worker-thread.ts
@@ -1,0 +1,10 @@
+import { parentPort, workerData } from "worker_threads";
+
+function factorial(n: number): number {
+  if (n === 1 || n === 0) {
+    return 1;
+  }
+  return factorial(n - 1) * n;
+}
+
+parentPort.postMessage(factorial(workerData.value));

--- a/series-13/main.ts
+++ b/series-13/main.ts
@@ -1,0 +1,4 @@
+// import "./examples/main-thread";
+// import "./examples/main-thread-message-channel";
+// import "./examples/main-thread-message-channel-array-buffer";
+import "./examples/main-thread-message-channel-shared-array-buffer";

--- a/series-13/package-lock.json
+++ b/series-13/package-lock.json
@@ -1,0 +1,213 @@
+{
+  "name": "typescript-node-series-1",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "typescript-node-series-1",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@types/node": "^20.11.5",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.3.3"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.11.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.6.tgz",
+      "integrity": "sha512-+EOokTnksGVgip2PbYbr3xnR7kZigh4LbybAfBAw5BpnQ+FqBYUsvCEjYd70IXKlbohQ64mzEYmMtlWUY8q//Q==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/series-13/package.json
+++ b/series-13/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "typescript-node-series-04",
+  "name": "typescript-node-series-13",
   "version": "1.0.0",
-  "description": "#4",
+  "description": "#13",
   "main": "index.js",
   "scripts": {
     "start": "ts-node ./main.ts"

--- a/series-13/reqeust.http
+++ b/series-13/reqeust.http
@@ -1,0 +1,2 @@
+GET https://localhost:8080/ HTTP/2.0
+ 

--- a/series-13/tsconfig.json
+++ b/series-13/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "sourceMap": true,
+    "target": "es2017",
+    "alwaysStrict": false,
+    "noImplicitAny": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
+  },
+  "exclude": ["node_modules"]
+}

--- a/series-13/worker.js
+++ b/series-13/worker.js
@@ -1,0 +1,5 @@
+const path = require("path");
+const { workerData } = require("worker_threads");
+
+require("ts-node").register();
+require(path.resolve(__dirname, workerData.path));


### PR DESCRIPTION
.gitignore, and implement worker thread examples

Standardized the naming convention of package.json for multiple projects, ensuring consistency and correct numbering format (series-01 to series-13). Updated the corresponding descriptions to match their series number. Created a .gitignore to exclude node_modules and .DS_Store files in series-13. Added ReadMe.md with usage instructions and main points for worker threads. Introduced various worker thread examples in TypeScript demonstrating message channels, shared array buffers, and factorial calculations. Introduced new scripts, dependencies, and configuration for TypeScript in series-13. Added HTTP request example.